### PR TITLE
fix delimiter is invalid in linknode

### DIFF
--- a/src/components/graph/Graph.tsx
+++ b/src/components/graph/Graph.tsx
@@ -132,11 +132,11 @@ export const Graph: FC<IGraphProps> = (props: IGraphProps) => {
         const currentNode = nodeMap.get(node.id);
         if (currentNode.isLinkNode) {
           node.x =
-            (nodeMap.get(currentNode.relatedNodes[0]).force.x ?? 0) * 0.5 +
-            (nodeMap.get(currentNode.relatedNodes[1]).force.x ?? 0) * 0.5;
+            (nodeMap.get(currentNode.relatedNodesOfLinkNode[0]).force.x ?? 0) * 0.5 +
+            (nodeMap.get(currentNode.relatedNodesOfLinkNode[1]).force.x ?? 0) * 0.5;
           node.y =
-            (nodeMap.get(currentNode.relatedNodes[0]).force.y ?? 0) * 0.5 +
-            (nodeMap.get(currentNode.relatedNodes[1]).force.y ?? 0) * 0.5;
+            (nodeMap.get(currentNode.relatedNodesOfLinkNode[0]).force.y ?? 0) * 0.5 +
+            (nodeMap.get(currentNode.relatedNodesOfLinkNode[1]).force.y ?? 0) * 0.5;
         }
       });
       forceUpdate();

--- a/src/components/graph/Graph.tsx
+++ b/src/components/graph/Graph.tsx
@@ -132,11 +132,11 @@ export const Graph: FC<IGraphProps> = (props: IGraphProps) => {
       nodeMap.getSimulationNodeDatums().forEach(node => {
         if (node.id.indexOf(CONST.LINK_NODE_PREFIX) !== -1) {
           node.x =
-            (nodeMap.get(node.id.split("-")[1]).force.x ?? 0) * 0.5 +
-            (nodeMap.get(node.id.split("-")[2]).force.x ?? 0) * 0.5;
+            (nodeMap.get(node.id.split("&")[1]).force.x ?? 0) * 0.5 +
+            (nodeMap.get(node.id.split("&")[2]).force.x ?? 0) * 0.5;
           node.y =
-            (nodeMap.get(node.id.split("-")[1]).force.y ?? 0) * 0.5 +
-            (nodeMap.get(node.id.split("-")[2]).force.y ?? 0) * 0.5;
+            (nodeMap.get(node.id.split("&")[1]).force.y ?? 0) * 0.5 +
+            (nodeMap.get(node.id.split("&")[2]).force.y ?? 0) * 0.5;
         }
       });
       forceUpdate();

--- a/src/components/graph/Graph.tsx
+++ b/src/components/graph/Graph.tsx
@@ -14,14 +14,13 @@ import {
   IGraphProps,
   IGraphPropsNode
 } from "./Graph.types";
-import { NodeMap,DELIMITER_SYMBOL } from "./NodeMap";
+import { NodeMap } from "./NodeMap";
 import { LinkMatrix } from "./LinkMatrix";
 import { throttle } from "lodash";
 import { mergeConfig } from "../../utils";
 import { DEFAULT_CONFIG } from "./graph.config";
 import { NodeModel } from "./NodeModel";
 import { LinkModel, getLinkNodeId } from "./LinkModel";
-import { default as CONST } from "./graph.const";
 import { LinkMap } from "./LinkMap";
 import { INodeCommonConfig } from "../node/Node.types";
 import {
@@ -130,13 +129,14 @@ export const Graph: FC<IGraphProps> = (props: IGraphProps) => {
     throttle(() => {
       const nodeMap: NodeMap = nodeMapRef.current;
       nodeMap.getSimulationNodeDatums().forEach(node => {
-        if (node.id.indexOf(CONST.LINK_NODE_PREFIX) !== -1) {
+        const currentNode = nodeMap.get(node.id);
+        if (currentNode.isLinkNode) {
           node.x =
-            (nodeMap.get(node.id.split(DELIMITER_SYMBOL)[1]).force.x ?? 0) * 0.5 +
-            (nodeMap.get(node.id.split(DELIMITER_SYMBOL)[2]).force.x ?? 0) * 0.5;
+            (nodeMap.get(currentNode.relatedNodes[0]).force.x ?? 0) * 0.5 +
+            (nodeMap.get(currentNode.relatedNodes[1]).force.x ?? 0) * 0.5;
           node.y =
-            (nodeMap.get(node.id.split(DELIMITER_SYMBOL)[1]).force.y ?? 0) * 0.5 +
-            (nodeMap.get(node.id.split(DELIMITER_SYMBOL)[2]).force.y ?? 0) * 0.5;
+            (nodeMap.get(currentNode.relatedNodes[0]).force.y ?? 0) * 0.5 +
+            (nodeMap.get(currentNode.relatedNodes[1]).force.y ?? 0) * 0.5;
         }
       });
       forceUpdate();
@@ -158,7 +158,7 @@ export const Graph: FC<IGraphProps> = (props: IGraphProps) => {
         "collide",
         d3.forceCollide(node => {
           if (
-            (node as IGraphNodeDatum).id.indexOf(CONST.LINK_NODE_PREFIX) !== -1
+            nodeMapRef.current.get((node as IGraphNodeDatum).id).isLinkNode
           ) {
             return 10;
           } else {

--- a/src/components/graph/Graph.tsx
+++ b/src/components/graph/Graph.tsx
@@ -14,7 +14,7 @@ import {
   IGraphProps,
   IGraphPropsNode
 } from "./Graph.types";
-import { NodeMap } from "./NodeMap";
+import { NodeMap,DELIMITER_SYMBOL } from "./NodeMap";
 import { LinkMatrix } from "./LinkMatrix";
 import { throttle } from "lodash";
 import { mergeConfig } from "../../utils";
@@ -132,11 +132,11 @@ export const Graph: FC<IGraphProps> = (props: IGraphProps) => {
       nodeMap.getSimulationNodeDatums().forEach(node => {
         if (node.id.indexOf(CONST.LINK_NODE_PREFIX) !== -1) {
           node.x =
-            (nodeMap.get(node.id.split("&")[1]).force.x ?? 0) * 0.5 +
-            (nodeMap.get(node.id.split("&")[2]).force.x ?? 0) * 0.5;
+            (nodeMap.get(node.id.split(DELIMITER_SYMBOL)[1]).force.x ?? 0) * 0.5 +
+            (nodeMap.get(node.id.split(DELIMITER_SYMBOL)[2]).force.x ?? 0) * 0.5;
           node.y =
-            (nodeMap.get(node.id.split("&")[1]).force.y ?? 0) * 0.5 +
-            (nodeMap.get(node.id.split("&")[2]).force.y ?? 0) * 0.5;
+            (nodeMap.get(node.id.split(DELIMITER_SYMBOL)[1]).force.y ?? 0) * 0.5 +
+            (nodeMap.get(node.id.split(DELIMITER_SYMBOL)[2]).force.y ?? 0) * 0.5;
         }
       });
       forceUpdate();

--- a/src/components/graph/LinkModel.tsx
+++ b/src/components/graph/LinkModel.tsx
@@ -84,7 +84,5 @@ export function getLinkNodeId(link: {
   source: string;
   target: string;
 }): string {
-  return `${CONST.LINK_NODE_PREFIX}${
-    link.source + DELIMITER_SYMBOL + link.target
-  }`;
+  return `${CONST.LINK_NODE_PREFIX}${link.source}${DELIMITER_SYMBOL}${link.target}`;
 }

--- a/src/components/graph/LinkModel.tsx
+++ b/src/components/graph/LinkModel.tsx
@@ -3,7 +3,7 @@ import { mergeConfig } from "../../utils";
 import { Link } from "../link/Link";
 import { ILinkCommonConfig, ILinkEnd } from "../link/Link.types";
 import { IGraphLinkDatum, IGraphPropsLink } from "./Graph.types";
-import { NodeMap } from "./NodeMap";
+import { NodeMap, DELIMITER_SYMBOL } from "./NodeMap";
 import { NodeModel } from "./NodeModel";
 import { default as CONST } from "./graph.const";
 
@@ -84,5 +84,7 @@ export function getLinkNodeId(link: {
   source: string;
   target: string;
 }): string {
-  return `${CONST.LINK_NODE_PREFIX}${link.source}&${link.target}`;
+  return `${CONST.LINK_NODE_PREFIX}${
+    link.source + DELIMITER_SYMBOL + link.target
+  }`;
 }

--- a/src/components/graph/LinkModel.tsx
+++ b/src/components/graph/LinkModel.tsx
@@ -3,9 +3,10 @@ import { mergeConfig } from "../../utils";
 import { Link } from "../link/Link";
 import { ILinkCommonConfig, ILinkEnd } from "../link/Link.types";
 import { IGraphLinkDatum, IGraphPropsLink } from "./Graph.types";
-import { NodeMap, DELIMITER_SYMBOL } from "./NodeMap";
+import { NodeMap } from "./NodeMap";
 import { NodeModel } from "./NodeModel";
 import { default as CONST } from "./graph.const";
+const DELIMITER_SYMBOL: string = ",";
 
 export class LinkModel {
   public sourceNode: NodeModel;

--- a/src/components/graph/LinkModel.tsx
+++ b/src/components/graph/LinkModel.tsx
@@ -84,5 +84,5 @@ export function getLinkNodeId(link: {
   source: string;
   target: string;
 }): string {
-  return `${CONST.LINK_NODE_PREFIX}${link.source}-${link.target}`;
+  return `${CONST.LINK_NODE_PREFIX}${link.source}&${link.target}`;
 }

--- a/src/components/graph/NodeMap.tsx
+++ b/src/components/graph/NodeMap.tsx
@@ -7,7 +7,6 @@ import {
 import { IZoomState, Ref } from "./Graph.types.internal";
 import { NodeModel } from "./NodeModel";
 import { getLinkNodeId } from "./LinkModel";
-export const : string = ",";
 export class NodeMap {
   public rootNode: NodeModel | undefined;
 

--- a/src/components/graph/NodeMap.tsx
+++ b/src/components/graph/NodeMap.tsx
@@ -2,12 +2,12 @@ import { INodeCommonConfig } from "../node/Node.types";
 import {
   IGraphNodeDatum,
   IGraphPropsLink,
-  IGraphPropsNode,
+  IGraphPropsNode
 } from "./Graph.types";
 import { IZoomState, Ref } from "./Graph.types.internal";
 import { NodeModel } from "./NodeModel";
-export const DELIMITER_SYMBOL: string = "Delimiter";
-
+import { getLinkNodeId } from "./LinkModel";
+export const DELIMITER_SYMBOL: string = ",";
 export class NodeMap {
   public rootNode: NodeModel | undefined;
 
@@ -49,30 +49,27 @@ export class NodeMap {
       }
     });
 
-    links.forEach((link) => {
-      if (
-        this._map.has(
-          `linkNode${DELIMITER_SYMBOL}${link.source}${DELIMITER_SYMBOL}${link.target}`
-        )
-      ) {
-        this._map
-          .get(
-            `linkNode${DELIMITER_SYMBOL}${link.source}${DELIMITER_SYMBOL}${link.target}`
-          )
-          ?.update(
-            {
-              id: `linkNode${DELIMITER_SYMBOL}${link.source}${DELIMITER_SYMBOL}${link.target}`,
-            },
-            {}
-          );
+    links.forEach(link => {
+      if (this._map.has(getLinkNodeId(link))) {
+        this._map.get(getLinkNodeId(link))?.update(
+          {
+            id: getLinkNodeId(link)
+          },
+          {},
+          [link.target,link.source],
+          true
+        );
       } else {
         this._map.set(
-          `linkNode${DELIMITER_SYMBOL}${link.source}${DELIMITER_SYMBOL}${link.target}`,
+          getLinkNodeId(link),
           new NodeModel(
             {
-              id: `linkNode${DELIMITER_SYMBOL}${link.source}${DELIMITER_SYMBOL}${link.target}`,
+              id: getLinkNodeId(link)
             },
-            {}
+            {},
+            undefined,
+            [link.target,link.source],
+            true
           )
         );
       }
@@ -100,7 +97,7 @@ export class NodeMap {
 
   public getSimulationNodeDatums(): IGraphNodeDatum[] {
     const datums: IGraphNodeDatum[] = [];
-    this._map.forEach((node) => datums.push(node.force));
+    this._map.forEach(node => datums.push(node.force));
     return datums;
   }
 }

--- a/src/components/graph/NodeMap.tsx
+++ b/src/components/graph/NodeMap.tsx
@@ -2,11 +2,11 @@ import { INodeCommonConfig } from "../node/Node.types";
 import {
   IGraphNodeDatum,
   IGraphPropsLink,
-  IGraphPropsNode
+  IGraphPropsNode,
 } from "./Graph.types";
 import { IZoomState, Ref } from "./Graph.types.internal";
 import { NodeModel } from "./NodeModel";
-export const DELIMITER_SYMBOL: string = "delimiter";
+export const DELIMITER_SYMBOL: string = "Delimiter";
 
 export class NodeMap {
   public rootNode: NodeModel | undefined;
@@ -52,35 +52,25 @@ export class NodeMap {
     links.forEach((link) => {
       if (
         this._map.has(
-          `linkNode${
-            DELIMITER_SYMBOL + link.source + DELIMITER_SYMBOL + link.target
-          }`
+          `linkNode${DELIMITER_SYMBOL}${link.source}${DELIMITER_SYMBOL}${link.target}`
         )
       ) {
         this._map
           .get(
-            `linkNode${
-              DELIMITER_SYMBOL + link.source + DELIMITER_SYMBOL + link.target
-            }`
+            `linkNode${DELIMITER_SYMBOL}${link.source}${DELIMITER_SYMBOL}${link.target}`
           )
           ?.update(
             {
-              id: `linkNode${
-                DELIMITER_SYMBOL + link.source + DELIMITER_SYMBOL + link.target
-              }`,
+              id: `linkNode${DELIMITER_SYMBOL}${link.source}${DELIMITER_SYMBOL}${link.target}`,
             },
             {}
           );
       } else {
         this._map.set(
-          `linkNode${
-            DELIMITER_SYMBOL + link.source + DELIMITER_SYMBOL + link.target
-          }`,
+          `linkNode${DELIMITER_SYMBOL}${link.source}${DELIMITER_SYMBOL}${link.target}`,
           new NodeModel(
             {
-              id: `linkNode${
-                DELIMITER_SYMBOL + link.source + DELIMITER_SYMBOL + link.target
-              }`,
+              id: `linkNode${DELIMITER_SYMBOL}${link.source}${DELIMITER_SYMBOL}${link.target}`,
             },
             {}
           )
@@ -110,7 +100,7 @@ export class NodeMap {
 
   public getSimulationNodeDatums(): IGraphNodeDatum[] {
     const datums: IGraphNodeDatum[] = [];
-    this._map.forEach(node => datums.push(node.force));
+    this._map.forEach((node) => datums.push(node.force));
     return datums;
   }
 }

--- a/src/components/graph/NodeMap.tsx
+++ b/src/components/graph/NodeMap.tsx
@@ -7,7 +7,7 @@ import {
 import { IZoomState, Ref } from "./Graph.types.internal";
 import { NodeModel } from "./NodeModel";
 import { getLinkNodeId } from "./LinkModel";
-export const DELIMITER_SYMBOL: string = ",";
+export const : string = ",";
 export class NodeMap {
   public rootNode: NodeModel | undefined;
 

--- a/src/components/graph/NodeMap.tsx
+++ b/src/components/graph/NodeMap.tsx
@@ -49,14 +49,14 @@ export class NodeMap {
     });
 
     links.forEach(link => {
-      if (this._map.has(`linkNode-${link.source}-${link.target}`)) {
+      if (this._map.has(`linkNode&${link.source}&${link.target}`)) {
         this._map
-          .get(`linkNode-${link.source}-${link.target}`)
-          ?.update({ id: `linkNode-${link.source}-${link.target}` }, {});
+          .get(`linkNode&${link.source}&${link.target}`)
+          ?.update({ id: `linkNode&${link.source}&${link.target}` }, {});
       } else {
         this._map.set(
-          `linkNode-${link.source}-${link.target}`,
-          new NodeModel({ id: `linkNode-${link.source}-${link.target}` }, {})
+          `linkNode&${link.source}&${link.target}`,
+          new NodeModel({ id: `linkNode&${link.source}&${link.target}` }, {})
         );
       }
     });

--- a/src/components/graph/NodeMap.tsx
+++ b/src/components/graph/NodeMap.tsx
@@ -6,6 +6,7 @@ import {
 } from "./Graph.types";
 import { IZoomState, Ref } from "./Graph.types.internal";
 import { NodeModel } from "./NodeModel";
+export const DELIMITER_SYMBOL: string = "delimiter";
 
 export class NodeMap {
   public rootNode: NodeModel | undefined;
@@ -48,15 +49,41 @@ export class NodeMap {
       }
     });
 
-    links.forEach(link => {
-      if (this._map.has(`linkNode&${link.source}&${link.target}`)) {
+    links.forEach((link) => {
+      if (
+        this._map.has(
+          `linkNode${
+            DELIMITER_SYMBOL + link.source + DELIMITER_SYMBOL + link.target
+          }`
+        )
+      ) {
         this._map
-          .get(`linkNode&${link.source}&${link.target}`)
-          ?.update({ id: `linkNode&${link.source}&${link.target}` }, {});
+          .get(
+            `linkNode${
+              DELIMITER_SYMBOL + link.source + DELIMITER_SYMBOL + link.target
+            }`
+          )
+          ?.update(
+            {
+              id: `linkNode${
+                DELIMITER_SYMBOL + link.source + DELIMITER_SYMBOL + link.target
+              }`,
+            },
+            {}
+          );
       } else {
         this._map.set(
-          `linkNode&${link.source}&${link.target}`,
-          new NodeModel({ id: `linkNode&${link.source}&${link.target}` }, {})
+          `linkNode${
+            DELIMITER_SYMBOL + link.source + DELIMITER_SYMBOL + link.target
+          }`,
+          new NodeModel(
+            {
+              id: `linkNode${
+                DELIMITER_SYMBOL + link.source + DELIMITER_SYMBOL + link.target
+              }`,
+            },
+            {}
+          )
         );
       }
     });

--- a/src/components/graph/NodeModel.tsx
+++ b/src/components/graph/NodeModel.tsx
@@ -11,11 +11,15 @@ export class NodeModel {
   public id: string;
   public size: number;
   public force: IGraphNodeDatum;
+  public relatedNodes: string[];
+  public isLinkNode: boolean;
 
   constructor(
     props: IGraphPropsNode,
     nodeConfig: INodeCommonConfig,
-    zoomStateRef?: Ref<IZoomState>
+    zoomStateRef?: Ref<IZoomState>,
+    relatedNodes?: string[],
+    isLinkNode?: boolean
   ) {
     this.id = props.id;
     this.size = props.size ?? 0;
@@ -28,16 +32,24 @@ export class NodeModel {
 
     this.props = mergeConfig(nodeConfig, props);
     this.size = this.props.size ?? 0;
+    this.relatedNodes = relatedNodes ?? [];
+    this.isLinkNode = isLinkNode ?? false;
   }
 
-  public update(props: IGraphPropsNode, nodeConfig: INodeCommonConfig) {
+  public update(
+    props: IGraphPropsNode,
+    nodeConfig: INodeCommonConfig,
+    relatedNodes?: string[],
+    isLinkNode?: boolean
+  ) {
     if (props.id !== this.props.id) {
       // TODO should not reach here
       return;
     }
-
     this.props = mergeConfig(nodeConfig, props);
     this.size = this.props.size ?? 0;
+    this.relatedNodes = relatedNodes ?? [];
+    this.isLinkNode = isLinkNode ?? false;
   }
 
   public renderNode(): JSX.Element {

--- a/src/components/graph/NodeModel.tsx
+++ b/src/components/graph/NodeModel.tsx
@@ -11,14 +11,14 @@ export class NodeModel {
   public id: string;
   public size: number;
   public force: IGraphNodeDatum;
-  public relatedNodes: string[];
+  public relatedNodesOfLinkNode: string[];
   public isLinkNode: boolean;
 
   constructor(
     props: IGraphPropsNode,
     nodeConfig: INodeCommonConfig,
     zoomStateRef?: Ref<IZoomState>,
-    relatedNodes?: string[],
+    relatedNodesOfLinkNode?: string[],
     isLinkNode?: boolean
   ) {
     this.id = props.id;
@@ -32,14 +32,14 @@ export class NodeModel {
 
     this.props = mergeConfig(nodeConfig, props);
     this.size = this.props.size ?? 0;
-    this.relatedNodes = relatedNodes ?? [];
-    this.isLinkNode = isLinkNode ?? false;
+    this.relatedNodesOfLinkNode = relatedNodesOfLinkNode ?? [];
+    this.isLinkNode = !!isLinkNode;
   }
 
   public update(
     props: IGraphPropsNode,
     nodeConfig: INodeCommonConfig,
-    relatedNodes?: string[],
+    relatedNodesOfLinkNode?: string[],
     isLinkNode?: boolean
   ) {
     if (props.id !== this.props.id) {
@@ -48,8 +48,8 @@ export class NodeModel {
     }
     this.props = mergeConfig(nodeConfig, props);
     this.size = this.props.size ?? 0;
-    this.relatedNodes = relatedNodes ?? [];
-    this.isLinkNode = isLinkNode ?? false;
+    this.relatedNodesOfLinkNode = relatedNodesOfLinkNode ?? [];
+    this.isLinkNode = !!isLinkNode;
   }
 
   public renderNode(): JSX.Element {

--- a/src/components/graph/graph.const.ts
+++ b/src/components/graph/graph.const.ts
@@ -2,5 +2,6 @@
  * @deprecated
  */
 export default {
-  LINK_NODE_PREFIX: "linkNode&"
+  LINK_NODE_PREFIX: "linkNodedelimiter"
 };
+

--- a/src/components/graph/graph.const.ts
+++ b/src/components/graph/graph.const.ts
@@ -1,8 +1,7 @@
-import { DELIMITER_SYMBOL } from "./NodeMap";
 /**
  * @deprecated
  */
 export default {
-  LINK_NODE_PREFIX: `linkNode${DELIMITER_SYMBOL}`
+  LINK_NODE_PREFIX: `linkNode-`
 };
 

--- a/src/components/graph/graph.const.ts
+++ b/src/components/graph/graph.const.ts
@@ -1,7 +1,8 @@
+import { DELIMITER_SYMBOL } from "./NodeMap";
 /**
  * @deprecated
  */
 export default {
-  LINK_NODE_PREFIX: "linkNodedelimiter"
+  LINK_NODE_PREFIX: `linkNode${DELIMITER_SYMBOL}`
 };
 

--- a/src/components/graph/graph.const.ts
+++ b/src/components/graph/graph.const.ts
@@ -2,5 +2,5 @@
  * @deprecated
  */
 export default {
-  LINK_NODE_PREFIX: "linkNode-"
+  LINK_NODE_PREFIX: "linkNode&"
 };


### PR DESCRIPTION
The origin delimiter of LinkNode is "-", but some node id already includes "-". So it will cause node position calculation failed and lead to style error as follow.  
To fix this, 
First, I add properties of relateNodes and isLinkNode to NodeModel, which can judge whether current node is linknode and get the related nodes of this linknode.
Second, I removed the logic dependency related to linknode id
![image](https://user-images.githubusercontent.com/19687611/124440865-ad35d880-ddad-11eb-8d6b-78394f7eecda.png)
![image](https://user-images.githubusercontent.com/19687611/124441933-d1de8000-ddae-11eb-9358-a7cd5e4c0cd3.png)

