### PR TITLE
change link click helper size

### DIFF
--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -18,7 +18,7 @@ export const DEFAULT_LINK_PROPS: ILinkCommonConfig = {
     background: "transparent"
   }
 };
-export const CLICK_HELPER_THRESHOLD: number = 4;
+export const CLICK_HELPER_THRESHOLD: number = 12;
 
 export const Link: FC<ILinkProps> = (props: ILinkProps) => {
   props = mergeConfig(DEFAULT_LINK_PROPS, props);
@@ -62,6 +62,7 @@ export const Link: FC<ILinkProps> = (props: ILinkProps) => {
   const clickHelperLineStyle: CSSProperties = {
     ...lineProps.style,
     opacity: 0,
+    cursor: "pointer",
     borderBottomWidth: CLICK_HELPER_THRESHOLD
   };
   const clickHelperLineProps: React.HTMLAttributes<HTMLDivElement> = {

--- a/stories/link/Styling.stories.tsx
+++ b/stories/link/Styling.stories.tsx
@@ -44,6 +44,15 @@ Styled.args = {
   }
 };
 
+export const ClickableLink: Story<ITemplateArgs> = Template.bind({});
+ClickableLink.args = {
+  linkProps: {
+    ...DEFAULT_REQUIRED_PROPS,
+    size: 4,
+    onClickLink: (ev, linkProps) => console.log("clicking on link: ", linkProps)
+  }
+};
+
 export const Offset: FC = () => (
   <div style={{ position: "absolute" }}>
     <Node


### PR DESCRIPTION
Change link click helper overlay to 12px.
Added an example in storybook:
![image](https://user-images.githubusercontent.com/15100664/140717513-31f14dc4-f7ad-4877-9dea-25be3e3e670e.png)

