### PR TITLE
Link updates

### DIFF
--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, FC, HTMLAttributes } from "react";
-import { mergeConfig } from "../../utils";
+import { css, mergeConfig } from "../../utils";
 import { calcDraw, len, deg, center } from "./Link.helper";
 import { ILinkCommonConfig, ILinkProps } from "./Link.types";
 
@@ -34,46 +34,45 @@ export const Link: FC<ILinkProps> = (props: ILinkProps) => {
     onKeyDown: event => props.onKeyDownLink?.(event, props)
   };
 
-  const lineCenterPos = center(start, end);
-  const linePosition: CSSProperties = {
-    width: len(start, end),
-    borderBottomWidth: props.size,
-    top: lineCenterPos.y,
-    left: lineCenterPos.x,
-    transform: `translate(-50%, -50%) rotate(${deg(start, end)}deg)`
-  };
-
-  const lineProps: HTMLAttributes<HTMLDivElement> = {
-    ...eventHandlers,
-    style: {
-      borderBottomColor: props.color,
-      borderBottomStyle: props.lineType,
-      ...linePosition,
-      ...props.lineStyle
-    },
-    tabIndex: props.focusable ? 0 : undefined,
-    "aria-label": props.lineAriaLabel
-  };
-
   const needClickHelper: boolean =
     !!props.onClickLink &&
     (!isFinite(props.size!) || props.size! < CLICK_HELPER_THRESHOLD);
 
-  const clickHelperLineStyle: CSSProperties = {
-    ...lineProps.style,
-    opacity: 0,
-    cursor: "pointer",
-    borderBottomWidth: CLICK_HELPER_THRESHOLD
-  };
-  const clickHelperLineProps: React.HTMLAttributes<HTMLDivElement> = {
+  const lineCenterPos = center(start, end);
+  const lineLength = len(start, end);
+  const lineProps: HTMLAttributes<HTMLDivElement> = {
     ...eventHandlers,
-    style: clickHelperLineStyle
+    ...props.customAttributes,
+    className: css(LINK_CLASS_LINE, props.customAttributes?.className),
+    style: {
+      position: "absolute",
+      width: lineLength,
+      height: props.size,
+      top: lineCenterPos.y,
+      left: lineCenterPos.x,
+      transform: `translate(-50%, -50%) rotate(${deg(start, end)}deg)`,
+      display: "flex",
+      alignItems: "center",
+      ...(needClickHelper && {
+        cursor: "pointer",
+        height: CLICK_HELPER_THRESHOLD
+      })
+    }
+  };
+
+  const lineInnerStyles: CSSProperties = {
+    borderBottomColor: props.color,
+    borderBottomStyle: props.lineType,
+    borderBottomWidth: props.size,
+    width: "100%",
+    ...props.lineStyle
   };
 
   return (
     <div className={LINK_CLASS_ROOT} style={props.style}>
-      <div className={LINK_CLASS_LINE} {...lineProps}></div>
-      {needClickHelper && <div {...clickHelperLineProps}></div>}
+      <div {...lineProps}>
+        <div style={lineInnerStyles}></div>
+      </div>
     </div>
   );
 };

--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -42,8 +42,8 @@ export const Link: FC<ILinkProps> = (props: ILinkProps) => {
   const lineLength = len(start, end);
   const lineProps: HTMLAttributes<HTMLDivElement> = {
     ...eventHandlers,
-    ...props.rootProps,
-    className: css(LINK_CLASS_LINE, props.rootProps?.className),
+    ...props.lineProps,
+    className: css(LINK_CLASS_LINE, props.lineProps?.className),
     style: {
       position: "absolute",
       width: lineLength,

--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -42,8 +42,8 @@ export const Link: FC<ILinkProps> = (props: ILinkProps) => {
   const lineLength = len(start, end);
   const lineProps: HTMLAttributes<HTMLDivElement> = {
     ...eventHandlers,
-    ...props.customAttributes,
-    className: css(LINK_CLASS_LINE, props.customAttributes?.className),
+    ...props.rootProps,
+    className: css(LINK_CLASS_LINE, props.rootProps?.className),
     style: {
       position: "absolute",
       width: lineLength,

--- a/src/components/link/Link.types.ts
+++ b/src/components/link/Link.types.ts
@@ -24,7 +24,7 @@ export interface ILinkCommonConfig extends ILinkEventHandlers {
   lineType?: ILinkType;
   style?: CSSProperties;
   lineStyle?: CSSProperties;
-  rootProps?: HTMLAttributes<HTMLDivElement>;
+  lineProps?: HTMLAttributes<HTMLDivElement>;
 }
 
 export interface ILinkEventHandlers {

--- a/src/components/link/Link.types.ts
+++ b/src/components/link/Link.types.ts
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from "react";
+import React, { CSSProperties, HTMLAttributes } from "react";
 
 export type ILinkType =
   | "none"
@@ -16,7 +16,6 @@ export interface ILinkProps extends ILinkCommonConfig {
   id: string;
   start: ILinkEnd;
   end: ILinkEnd;
-  lineAriaLabel?: string;
 }
 
 export interface ILinkCommonConfig extends ILinkEventHandlers {
@@ -24,9 +23,8 @@ export interface ILinkCommonConfig extends ILinkEventHandlers {
   color?: string;
   lineType?: ILinkType;
   style?: CSSProperties;
-  className?: string;
   lineStyle?: CSSProperties;
-  focusable?: boolean;
+  customAttributes?: HTMLAttributes<HTMLDivElement>;
 }
 
 export interface ILinkEventHandlers {

--- a/src/components/link/Link.types.ts
+++ b/src/components/link/Link.types.ts
@@ -24,7 +24,7 @@ export interface ILinkCommonConfig extends ILinkEventHandlers {
   lineType?: ILinkType;
   style?: CSSProperties;
   lineStyle?: CSSProperties;
-  customAttributes?: HTMLAttributes<HTMLDivElement>;
+  rootProps?: HTMLAttributes<HTMLDivElement>;
 }
 
 export interface ILinkEventHandlers {

--- a/stories/graph/Graph.stories.tsx
+++ b/stories/graph/Graph.stories.tsx
@@ -182,7 +182,7 @@ Complex.args = {
     },
     linkConfig: {
       onClickLink: (ev, linkProps) => console.log("Clicked on link", linkProps),
-      customAttributes: { className: "link-test", tabIndex: 0 }
+      rootProps: { className: "link-test", tabIndex: 0 }
     },
     config: {
       sim: {

--- a/stories/graph/Graph.stories.tsx
+++ b/stories/graph/Graph.stories.tsx
@@ -182,7 +182,7 @@ Complex.args = {
     },
     linkConfig: {
       onClickLink: (ev, linkProps) => console.log("Clicked on link", linkProps),
-      rootProps: { className: "link-test", tabIndex: 0 }
+      lineProps: { className: "link-test", tabIndex: 0 }
     },
     config: {
       sim: {

--- a/stories/graph/Graph.stories.tsx
+++ b/stories/graph/Graph.stories.tsx
@@ -89,7 +89,7 @@ Styled.args = {
     },
     linkConfig: {
       lineStyle: {
-        stroke: "deepskyblue"
+        borderColor: "deepskyblue"
       }
     }
   }
@@ -181,7 +181,8 @@ Complex.args = {
       nodeFocusable: true
     },
     linkConfig: {
-      focusable: true
+      onClickLink: (ev, linkProps) => console.log("Clicked on link", linkProps),
+      customAttributes: { className: "link-test", tabIndex: 0 }
     },
     config: {
       sim: {


### PR DESCRIPTION
1. support adding custom attributes
This is mainly for a11y. A11y has a lot of attributes and we don't want to mess up configs.
In addition, custom className is supported. This will help with adding hover style to it.
2. re-organized link structure
Make the link itself wider when `clickHelper` is needed, instead of adding another element covers on it. 

Before:
![image](https://user-images.githubusercontent.com/15100664/145976396-5f178470-1156-4ead-80e4-4e27b977ff4b.png)

After:
![image](https://user-images.githubusercontent.com/15100664/145976189-8ea07d91-de8c-4960-b837-b3432edc06c7.png)
