### PR TITLE
fix main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.2.3",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/fluent-graph.js",
   "typings": "lib/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
To fix the bundle issue please also add these in the react presets `webpack.output`

```
                    library: opackage.name,
                    libraryTarget: "umd",
                    umdNamedDefine: true,
```

otherwise the consumer won't be able to find peerDependencies